### PR TITLE
fix: enhanced caret position offset

### DIFF
--- a/spellchecker/textarea.js
+++ b/spellchecker/textarea.js
@@ -77,6 +77,7 @@ class SpellCheckInput extends LitElement {
               @replace=${(e) => {
                 const typo = this.typos[this.typoIndex];
                 const suggestion = e.detail.suggestion;
+                const originLength = this.content.length;
 
                 this.setContent(
                   this.content.substring(0, typo.from + this.offset) +
@@ -84,8 +85,7 @@ class SpellCheckInput extends LitElement {
                     this.content.substring(typo.to + this.offset)
                 );
 
-                this.offset += suggestion.length - typo.token.length;
-
+                this.offset += this.content.length - originLength;
                 this.goIndex();
               }}
               @close=${() => this.closeModal()}


### PR DESCRIPTION
맞춤법 검사기에서 잘못된 토큰 길이를 넘겨주는 경우가 발견되어, 실제 수정된 텍스트 길이 기반으로 오프셋 계산을 수정하였습니다.