### PR TITLE
U+2018, U+2019, U+201C, U+201D (작은 따옴표‘ , 큰 따옴표“)에 대한 바이트 수 계산 오류

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,10 +93,11 @@
             var english = content.replace(/[ㄱ-ㅎ|ㅏ-ㅣ|가-힣]/gi, "").replace(/[0-9]/gi, "").replace(/[\{\}\[\]\/?.,;:|\)*~`!^\-_+<>@\#$%&\\\=\(\'\"]/gi, "").replace(/\s/gi, "").replace(/\s/gi, "").replace(/(\r\n\t|\n|\r\t)/gm,"").replace(/‘|’|“|”/g, "");
             var korean = content.replace(/[a-zA-Z]/gi, "").replace(/[0-9]/gi, "").replace(/[\{\}\[\]\/?.,;:|\)*~`!^\-_+<>@\#$%&\\\=\(\'\"]/gi, "").replace(/\s/gi, "").replace(/(\r\n\t|\n|\r\t)/gm,"").replace(/‘|’|“|”/g, "");
             var number = content.replace(/[a-zA-Z]/gi, "").replace(/[ㄱ-ㅎ|ㅏ-ㅣ|가-힣]/gi, "").replace(/[\{\}\[\]\/?.,;:|\)*~`!^\-_+<>@\#$%&\\\=\(\'\"]/gi, "").replace(/\s/gi, "").replace(/(\r\n\t|\n|\r\t)/gm,"").replace(/‘|’|“|”/g, "");
-            var special = content.replace(/[a-zA-Z]/gi, "").replace(/[ㄱ-ㅎ|ㅏ-ㅣ|가-힣]/gi, "").replace(/[0-9]/gi, "").replace(/\s/gi, "").replace(/(\r\n\t|\n|\r\t)/gm,"");
+            var onebyte_special = content.replace(/[a-zA-Z]/gi, "").replace(/[ㄱ-ㅎ|ㅏ-ㅣ|가-힣]/gi, "").replace(/[0-9]/gi, "").replace(/\s/gi, "").replace(/(\r\n\t|\n|\r\t)/gm,"").replace(/‘|’|“|”/g, "");
+            var threebyte_special = content.replace(/[a-zA-Z]/gi, "").replace(/[ㄱ-ㅎ|ㅏ-ㅣ|가-힣]/gi, "").replace(/[0-9]/gi, "").replace(/[\{\}\[\]\/?.,;:|\)*~`!^\-_+<>@\#$%&\\\=\(\'\"]/gi, "").replace(/\s/gi, "").replace(/(\r\n\t|\n|\r\t)/gm,"");
             var space =  content.replace(/[a-zA-Z]/gi, "").replace(/[ㄱ-ㅎ|ㅏ-ㅣ|가-힣]/gi, "").replace(/[\{\}\[\]\/?.,;:|\)*~`!^\-_+<>@\#$%&\\\=\(\'\"]/gi, "").replace(/[0-9]/gi, "").replace(/(\r\n\t|\n|\r\t)/gm,"").replace(/‘|’|“|”/g, "");
             var line = content.replace(/[a-zA-Z]/gi, "").replace(/[ㄱ-ㅎ|ㅏ-ㅣ|가-힣]/gi, "").replace(/[\{\}\[\]\/?.,;:|\)*~`!^\-_+<>@\#$%&\\\=\(\'\"]/gi, "").replace(/[0-9]/gi, "").replace(/ /gi, "").replace(/‘|’|“|”/g, "");
-            var result = english.length + (korean.length * 3) +  number.length + special.length + space.length + (line.length * 2);
+            var result = english.length + (korean.length * 3) +  number.length + onebyte_special.length + (threebyte_special.length * 3) + space.length + (line.length * 2);
             document.getElementById('result').innerHTML = "공백 제외 " + content.replace(/(\r\n\t|\n|\r\t)/gm,"").replace(/ /gi, "").length + "자, 공백 포함 " + content.length + "자, " + result + "바이트";
         }    
 


### PR DESCRIPTION
다른 곳에서 글을 복사할때 가끔씩 나타나는 ‘ 작은 따옴표와 “ 큰따옴표가 3바이트가 아닌 1바이트로 계산되는 오류가 있습니다.
해당 특수문자는 위키백과 UTF-8 문서를 찾은 결과 3바이트로 명시 되어있고, 직접 영어 세특을 입력할 때에 해당 사이트와 생기부 입력시의 바이트 수를 비교해 본 결과 3바이트로 계산됨을 확인하였습니다. 이에 따라 해당 사이트에서도 해당 특수문자를 3바이트로 계산하는 것을 요청하는 바입니다.

+ 첫 PR이여서 예상치 못한 오류나 미숙한 부분이 있을 수 있다는 점 양해해 주시면 고맙겠습니다.